### PR TITLE
Fix book creation, added checks & fixed input params

### DIFF
--- a/LibraryWebApp/Controllers/BookController.cs
+++ b/LibraryWebApp/Controllers/BookController.cs
@@ -55,8 +55,13 @@ namespace LibraryWebApp.Controllers
         [ValidateAntiForgeryToken]
         public async Task<IActionResult> Create(Book book) // TODO should probrably switch to using ViewModels
         {
+            if (book.PublicationDate > DateOnly.FromDateTime(DateTime.Today))
+            {
+                ModelState.AddModelError("PublicationDate", "The publication date cannot be in the future.");
+            }
             if (ModelState.IsValid)
             {
+                book.AvailableCount = book.TotalCount;
                 _context.Add(book);
                 await _context.SaveChangesAsync();
                 return RedirectToAction(nameof(Index));

--- a/LibraryWebApp/Controllers/BookController.cs
+++ b/LibraryWebApp/Controllers/BookController.cs
@@ -55,10 +55,8 @@ namespace LibraryWebApp.Controllers
         [ValidateAntiForgeryToken]
         public async Task<IActionResult> Create(Book book) // TODO should probrably switch to using ViewModels
         {
-            if (book.PublicationDate > DateOnly.FromDateTime(DateTime.Today))
-            {
-                ModelState.AddModelError("PublicationDate", "The publication date cannot be in the future.");
-            }
+            ValidatePublicationDate(book.PublicationDate);
+
             if (ModelState.IsValid)
             {
                 book.AvailableCount = book.TotalCount;
@@ -90,6 +88,8 @@ namespace LibraryWebApp.Controllers
         [ValidateAntiForgeryToken]
         public async Task<IActionResult> Edit(Book book)
         {
+            ValidatePublicationDate(book.PublicationDate);
+
             if (ModelState.IsValid)
             {
                 _context.Update(book);
@@ -134,9 +134,12 @@ namespace LibraryWebApp.Controllers
             return RedirectToAction(nameof(Index));
         }
 
-        private bool BookExists(int id)
+        private void ValidatePublicationDate(DateOnly publicationDate) 
         {
-            return _context.Books.Any(b => b.Id == id);
+            if (publicationDate > DateOnly.FromDateTime(DateTime.Today))
+            {
+                ModelState.AddModelError("PublicationDate", "The publication date cannot be in the future.");
+            }
         }
     }
 }

--- a/LibraryWebApp/Models/Book.cs
+++ b/LibraryWebApp/Models/Book.cs
@@ -8,7 +8,7 @@ namespace LibraryWebApp.Models
     {
         [Key]
         public int Id { get; set; }
-
+        [RegularExpression(@"^[^\/\\:\*\<>\|]+$", ErrorMessage = "The Title contains invalid characters.")]
         public string Title { get; set; }
 
         [DisplayName("Publication Date")]

--- a/LibraryWebApp/Views/Book/Create.cshtml
+++ b/LibraryWebApp/Views/Book/Create.cshtml
@@ -19,13 +19,8 @@
             </div>
             <div class="form-group">
                 <label asp-for="PublicationDate" class="control-label"></label>
-                <input asp-for="PublicationDate" class="form-control" type="date" />
+                <input asp-for="PublicationDate" class="form-control" type="date"/>
                 <span asp-validation-for="PublicationDate" class="text-danger"></span>
-            </div>
-            <div class="form-group">
-                <label asp-for="AvailableCount" class="control-label"></label>
-                <input asp-for="AvailableCount" class="form-control" />
-                <span asp-validation-for="AvailableCount" class="text-danger"></span>
             </div>
             <div class="form-group">
                 <label asp-for="TotalCount" class="control-label"></label>


### PR DESCRIPTION
deleted the AvailableCount from book creation screen and added a line in the controller's creation method to set it equal to the total count Made the date impossible to be set to a future point in time (in create method | could be made client side by adding a max to the input field in Create.cshtml, but that can get easily bypassed), as we should not rent a book we do not have yet.