### PR TITLE
Bugfix/fix filtering based on author and genre

### DIFF
--- a/LibraryWebApp/Controllers/HomeController.cs
+++ b/LibraryWebApp/Controllers/HomeController.cs
@@ -71,12 +71,12 @@ namespace LibraryWebApp.Controllers
                     case SearchBy.Author:
                         books = books
                         .Include(b => b.Authors)
-                        .Where(b => b.Authors.Any(a => a.Name.Contains(searchTerm, StringComparison.OrdinalIgnoreCase)));
+                        .Where(b => b.Authors.Any(a => a.Name.Contains(searchTerm)));
                         break;
                     case SearchBy.Genre:
                         books = books
                        .Include(b => b.Genres)
-                       .Where(b => b.Genres.Any(g => g.Name.Contains(searchTerm, StringComparison.OrdinalIgnoreCase)));
+                       .Where(b => b.Genres.Any(g => g.Name.Contains(searchTerm)));
                         break;
                 }
             }


### PR DESCRIPTION
Just a small fix

Entity framework uses case insensitive filtering when using `.Contains` to generate a `LIKE` sql query, so the second argument was useless and it was throwing an error because of it