### PR TITLE
Fix broken book links due to invalid Book id being passed

### DIFF
--- a/LibraryWebApp/Views/BookRentals/Details.cshtml
+++ b/LibraryWebApp/Views/BookRentals/Details.cshtml
@@ -47,7 +47,7 @@
             var isSoonOverdue = currentDate.AddDays(Globals.RentDeadlineWarningPeriod) >= book.Deadline && !(book.ReturnedAt.HasValue);
             <tr class="@(isSoonOverdue ? "table-danger" : "")">
                 <td>
-                    <a asp-controller="Book" asp-action="Details" asp-route-id="@book.Id")>@book.Book.Title</a>
+                    <a asp-controller="Book" asp-action="Details" asp-route-id="@book.BookId")>@book.Book.Title</a>
                 </td>
                 <td>
                     @book.RentalDate.ToString(Globals.DateFormat)


### PR DESCRIPTION
book.Id did not reflect the real id of a given book

Changed to book.BookId