### PR TITLE
Add book cover image preview when uploading new book covers

### DIFF
--- a/LibraryWebApp/Controllers/BookController.cs
+++ b/LibraryWebApp/Controllers/BookController.cs
@@ -98,7 +98,7 @@ namespace LibraryWebApp.Controllers
                         .ToListAsync(),
                 };
 
-                // Save a brand new cover image if it was provided
+                // Save a brand new cover image if it was provided (checks for null automatically)
                 await SaveBookCoverImage(book, coverImage);
 
                 _context.Books.Add(book);
@@ -178,7 +178,7 @@ namespace LibraryWebApp.Controllers
                         _bookCoverImageManager.DeleteBookCoverImage(bookInDb.CoverImageUrl);
                     }
 
-                    // Save a brand new cover image if it was provided
+                    // Save a brand new cover image if it was provided (checks for null automatically)
                     await SaveBookCoverImage(bookInDb, coverImage);
                 }
 

--- a/LibraryWebApp/Controllers/BookController.cs
+++ b/LibraryWebApp/Controllers/BookController.cs
@@ -169,17 +169,18 @@ namespace LibraryWebApp.Controllers
                 bookInDb.AvailableCount = vm.AvailableCount;
                 bookInDb.PublicationDate = vm.PublicationDate;
 
-                // Always delete old cover image if it exists
-                if (!string.IsNullOrEmpty(bookInDb.CoverImageUrl))
-
-                // If the book had a cover image already saved in the database, delete it
-                if (bookInDb.CoverImageUrl != null)
+                // Only if the user made some changes to the book cover image, then we need to handle it
+                if (vm.IsBookCoverChanged) 
                 {
-                    _bookCoverImageManager.DeleteBookCoverImage(bookInDb.CoverImageUrl);
-                }
+                    // If the book had a cover image already saved in the database, delete it
+                    if (bookInDb.CoverImageUrl != null)
+                    {
+                        _bookCoverImageManager.DeleteBookCoverImage(bookInDb.CoverImageUrl);
+                    }
 
-                // Save a brand new cover image if it was provided
-                await SaveBookCoverImage(bookInDb, coverImage);
+                    // Save a brand new cover image if it was provided
+                    await SaveBookCoverImage(bookInDb, coverImage);
+                }
 
                 var selectedAuthors = await _context.Authors
                     .Where(a => vm.SelectedAuthorIDs.Contains(a.Id))

--- a/LibraryWebApp/ViewModels/BookViewModels/BookEditVM.cs
+++ b/LibraryWebApp/ViewModels/BookViewModels/BookEditVM.cs
@@ -6,5 +6,7 @@ namespace LibraryWebApp.ViewModels.BookViewModels
     {
         [DisplayName("Available Count")]
         public int AvailableCount { get; set; }
+
+        public bool IsBookCoverChanged { get; set; } = false; // Needed in order to handle cases where the user does not want to override the book cover image
     }
 }

--- a/LibraryWebApp/Views/Book/Create.cshtml
+++ b/LibraryWebApp/Views/Book/Create.cshtml
@@ -13,10 +13,25 @@
     <div class="col-md-4">
         <form asp-controller="Book" asp-action="Create" enctype="multipart/form-data">
             <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+            <input type="hidden" asp-for="CoverImageUrl" class="form-control" />
             <input type="hidden" asp-for="DefaultCoverImageUrl" />
+
+            <div class="form-group" style="max-width: 300px;">
+                <label class="control-label">Cover Image</label>
+                <div class="card border border-primary rounded">
+                    <div id="image-container" class="card-img-container" style="width: 100%; height: 250px; display: flex; justify-content: center; align-items: center; overflow: hidden; background-color: #f8f9fa;">
+                        <img id="cover-image" src="@(Model.CoverImageUrl ?? Model.DefaultCoverImageUrl)"
+                             style="max-width: 100%; max-height: 100%; object-fit: scale-down;"
+                             alt="Book Cover">
+                    </div>
+                </div>
+            </div>
             <div class="form-group">
                 <label class="control-label"></label>
-                <input type="file" name="coverImage" class="form-control" />
+                <div style="display: flex; gap: 10px; align-items: center;">
+                    <input id="file-input" type="file" name="coverImage" class="form-control" accept="image/*" />
+                    <button id="clear-button" type="button" class="btn btn-danger">Clear</button>
+                </div>
             </div>
             <div class="form-group">
                 <label asp-for="Title" class="control-label"></label>
@@ -60,4 +75,21 @@
 
 @section Scripts {
     <partial name="_ValidationScriptsPartial" />
+
+    <script src="~/js/display_uploaded_file_image.js"></script>
+    <script src="~/js/clear_displayed_image.js"></script>
+
+    <script>
+            document.addEventListener('DOMContentLoaded', function () {
+            setupImagePreview('file-input', 'cover-image');
+
+            const fileInput = document.getElementById('file-input');
+            
+            // Correctly pass as a JavaScript string
+            const defaultCoverImageUrl = "@(Model.DefaultCoverImageUrl.Replace("\\", "\\\\").Replace("\"", "\\\""))";
+            setupClearButton('cover-image', 'clear-button', 'file-input', defaultCoverImageUrl, 'is-book-cover-changed');
+        });
+
+    </script>
+
 }

--- a/LibraryWebApp/Views/Book/Edit.cshtml
+++ b/LibraryWebApp/Views/Book/Edit.cshtml
@@ -15,10 +15,24 @@
             <input type="hidden" asp-for="Id" />
             <input type="hidden" asp-for="CoverImageUrl" class="form-control" />
             <input type="hidden" asp-for="DefaultCoverImageUrl" />
+            <input id="is-book-cover-changed" type="hidden" asp-for="IsBookCoverChanged" class="form-control" />
 
+            <div class="form-group" style="max-width: 300px;">
+                <label class="control-label">Cover Image</label>
+                <div class="card border border-primary rounded">
+                    <div id="image-container" class="card-img-container" style="width: 100%; height: 250px; display: flex; justify-content: center; align-items: center; overflow: hidden; background-color: #f8f9fa;">
+                        <img id="cover-image" src="@(Model.CoverImageUrl ?? Model.DefaultCoverImageUrl)"
+                             style="max-width: 100%; max-height: 100%; object-fit: scale-down;"
+                             alt="Book Cover">
+                    </div>
+                </div>
+            </div>
             <div class="form-group">
                 <label class="control-label"></label>
-                <input type="file" name="coverImage" class="form-control" />
+                <div style="display: flex; gap: 10px; align-items: center;">
+                    <input id="file-input" type="file" name="coverImage" class="form-control" accept="image/*" />
+                    <button id="clear-button" type="button" class="btn btn-danger">Clear</button>
+                </div>
             </div>
             <div class="form-group">
                 <label asp-for="Title" class="control-label"></label>
@@ -65,4 +79,28 @@
 
 @section Scripts {
     <partial name="_ValidationScriptsPartial" />
+    <script src="~/js/display_uploaded_file_image.js"></script>
+    <script src="~/js/clear_displayed_image.js"></script>
+
+    <script>
+            document.addEventListener('DOMContentLoaded', function () {
+            setupImagePreview('file-input', 'cover-image');
+
+            const fileInput = document.getElementById('file-input');
+            const hiddenField = document.getElementById('is-book-cover-changed');
+
+            if (fileInput && hiddenField) {
+                fileInput.addEventListener('change', function () {
+                    hiddenField.value = 'true'; // Handle cases where a new cover image is uploaded
+                });
+            }
+
+            // Correctly pass as a JavaScript string
+            const defaultCoverImageUrl = "@(Model.DefaultCoverImageUrl.Replace("\\", "\\\\").Replace("\"", "\\\""))";
+            setupClearButton('cover-image', 'clear-button', 'file-input', defaultCoverImageUrl, 'is-book-cover-changed');
+        });
+
+    </script>
+
+
 }

--- a/LibraryWebApp/wwwroot/js/clear_displayed_image.js
+++ b/LibraryWebApp/wwwroot/js/clear_displayed_image.js
@@ -1,4 +1,4 @@
-﻿function setupClearButton(imgTagId, clearButtonId, fileInputId, defaultCoverImage, hiddenFieldId) {
+﻿function setupClearButton(imgTagId, clearButtonId, fileInputId, defaultCoverImage, hiddenFieldId = null) {
     const imgTag = document.getElementById(imgTagId);
     const clearButton = document.getElementById(clearButtonId);
     const fileInput = document.getElementById(fileInputId);
@@ -14,9 +14,11 @@
         // Reset the image to the default
         imgTag.src = defaultCoverImage;
 
-        const hiddenField = document.getElementById(hiddenFieldId);
-        if (hiddenField) {
-            hiddenField.value = 'true'; 
+        if (hiddenFieldId != null) {
+            const hiddenField = document.getElementById(hiddenFieldId);
+            if (hiddenField) {
+                hiddenField.value = 'true';
+            }
         }
     });
 }

--- a/LibraryWebApp/wwwroot/js/clear_displayed_image.js
+++ b/LibraryWebApp/wwwroot/js/clear_displayed_image.js
@@ -1,0 +1,22 @@
+﻿function setupClearButton(imgTagId, clearButtonId, fileInputId, defaultCoverImage, hiddenFieldId) {
+    const imgTag = document.getElementById(imgTagId);
+    const clearButton = document.getElementById(clearButtonId);
+    const fileInput = document.getElementById(fileInputId);
+
+    if (!imgTag || !clearButton || !fileInput) {
+        console.error(`Invalid IDs provided. Make sure #${imgTagId}, #${clearButtonId}, and #${fileInputId} exist.`);
+        return;
+    }
+
+    clearButton.addEventListener('click', function () {
+        fileInput.value = null; // Clear the file input
+
+        // Reset the image to the default
+        imgTag.src = defaultCoverImage;
+
+        const hiddenField = document.getElementById(hiddenFieldId);
+        if (hiddenField) {
+            hiddenField.value = 'true'; 
+        }
+    });
+}

--- a/LibraryWebApp/wwwroot/js/display_uploaded_file_image.js
+++ b/LibraryWebApp/wwwroot/js/display_uploaded_file_image.js
@@ -1,0 +1,24 @@
+﻿function setupImagePreview(fileInputId, imgTagId) {
+    const fileInput = document.getElementById(fileInputId);
+    const imgTag = document.getElementById(imgTagId);
+
+    if (!fileInput || !imgTag) {
+        console.error(`Invalid IDs provided. Make sure #${fileInputId} and #${imgTagId} exist.`);
+        return;
+    }
+
+    fileInput.addEventListener('change', function (event) {
+        const file = event.target.files[0]; // Get the first selected file
+        if (file && file.type.startsWith('image/')) {
+            const reader = new FileReader();
+
+            reader.onload = function (e) {
+                imgTag.src = e.target.result; // Update the image src
+            };
+
+            reader.readAsDataURL(file); // Read the file as a data URL
+        } else {
+            alert('Please upload a valid image file.');
+        }
+    });
+}


### PR DESCRIPTION
1. Fix book cover image being set to null when a user edits only other unrelated fields
2. Add preview for uploaded book covers
3. Add clear book cover button that clears the currently uploaded image file

All of this was done by writing some JavaScript files and adding the `IsBookCoverChanged` in the `BookEditVM` that tracks whether the user has touched the file input field or not - this accomplishes the first fix I mentioned